### PR TITLE
fix issue #1 by correcting refillAllowance computation of newLastAcce…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ func main() {
 * Expand testcases in refillAllowanceTests
 * Go testing badge
 * Some kind of benchmarking
+* more specific error handling within ratelimit.go, remove negative value returns 
+* map out all possible code paths perhaps with code coverage tooling
+* create tags/releases to protect backwards compatibility
+* create example usages within an http application / http middleware

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -151,6 +151,6 @@ func refillAllowance(currentTime, previousAllowance, previousLastAccessedTimesta
 		return newAllowance, currentTime
 	}
 
-	// always return currentTime
-	return previousAllowance, currentTime
+	// if no changes are made to the allowance, return the previous allowance and accessedTimestamp
+	return previousAllowance, previousLastAccessedTimestampNS
 }


### PR DESCRIPTION
This PR fixes an issue where the bucket wasn't being refilled due to lastAccessedTimestampNS being incorrectly calculated.